### PR TITLE
session-binding-race-cross-account

### DIFF
--- a/apps/wallet/src/lib/api/useBackendSessionSync.ts
+++ b/apps/wallet/src/lib/api/useBackendSessionSync.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import { useWalletProfile } from '~/lib/wallet/useWallet';
+import { getUnlockedSlot } from '~/lib/wallet/vault';
+import { clearAccessToken } from '~/lib/api/client';
+import { getSessionAddress } from '~/lib/api/session';
+
+/**
+ * Keeps the backend session bound to the active wallet account. On account switch — and on
+ * first entry to the authed shell after unlock/create — re-runs SIWX for the active account
+ * so per-account staking data (deposit memo, position) reflects the right backend user
+ * instead of whichever account happened to sign in first.
+ *
+ * Ledger accounts hold no client-side secret, so they cannot SIWX this way and are skipped
+ * (their backend session, if any, is established elsewhere).
+ */
+export function useBackendSessionSync(): void {
+  const { profile } = useWalletProfile();
+  const address = profile?.address ?? null;
+  const attempting = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!address || !profile) return;
+    if (getSessionAddress() === address) return; // already bound to this account
+    if (attempting.current === address) return; // attempt already in flight
+    const slot = getUnlockedSlot(profile.id);
+    if (!slot?.secret) {
+      // Ledger / no client-side secret: can't SIWX. Drop any other account's session so the
+      // staking views show nothing rather than the previous account's memo/position.
+      if (getSessionAddress() !== null) clearAccessToken();
+      return;
+    }
+
+    attempting.current = address;
+    let cancelled = false;
+    void (async () => {
+      try {
+        clearAccessToken(); // unbind token + session → per-account queries pause (no stale flash)
+        const { walletSignIn } = await import('~/features/auth/walletSignIn');
+        await walletSignIn({ seed: slot.secret, address }); // re-binds the session on success
+        // A newer account switch may have superseded this attempt while the SIWX round-trip was
+        // in flight. walletSignIn unconditionally binds the session to `address`, so a stale
+        // attempt that resolves last would leave the token/session pointing at the wrong account
+        // — per-account queries (staking position, deposit destination tag, withdrawal prefill)
+        // would then load/act on another account's data. If this superseded attempt won the race,
+        // drop its binding so we never show or transact under the wrong account.
+        if (cancelled && getSessionAddress() === address) {
+          clearAccessToken();
+        }
+      } catch {
+        // best-effort: leave the session unbound; it retries on the next account/profile change
+      } finally {
+        if (!cancelled && attempting.current === address) attempting.current = null;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address, profile]);
+}


### PR DESCRIPTION
## Backend session binding race condition → cross-account data leak

- **Severity:** High (vulnerability: cross-account data leakage + possible incorrect payment direction)
- **File:** `apps/wallet/src/lib/api/useBackendSessionSync.ts`
- **Class:** race condition / violation of the invariant “session is bound to the active account”

## Symptom / Impact

`useBackendSessionSync` maintains the invariant that the backend session (JWT + `boundAddress`) must
point to the active account. All per-account requests (`useMe`, `useStakingDepositAddress`,
`useReferrals`, etc.) include `session` in the query key, so when desynchronization occurs under
account A, data from account B is shown: balance/ staking position, **destination tag of the deposit**,
and the prefilled withdrawal address.

## Root Cause

At the end of `walletSignIn()`, it **unconditionally** calls `setSessionAddress(address)` (and
`verifyWalletSignature` sets the access token). The hook only guarded against a duplicated attempt
for the **same** address (`attempting.current === address`), but it did not ignore the result of an
outdated attempt for a **different** address—`cancelled` only prevented resetting
`attempting.current`.

## Failure Scenario

1. The session is bound to A.
2. The user switches A → B (starts `walletSignIn(B)`, the token is cleared — requests are paused).
3. Quickly switches B → A (starts `walletSignIn(A)`).
4. Both attempts are in flight. If the network round-trip for B completes **later** than A, its
   final `setSessionAddress('B')` + token=B win.
5. The active profile is A, but `boundAddress`/token = B → balance, staking position, referral
   accruals, and the **destination tag for B’s staking deposit** are shown. The deposit from
   `StakeModal` will go with tag B → it will be credited to the wrong backend user; the withdrawal
   form will also prefill with address B.

The state self-heals only on the next vault mutation (when the `profile` identity changes).

## Fix

After `await walletSignIn(...)`, check whether the attempt was displaced by a newer switch.
If the outdated attempt “won the race” and is currently bound, reset its binding so it’s never used
to display/transfer data under another account (safe state = “not bound”; requests are paused;
resync will happen on the next profile change).

```ts
await walletSignIn({ seed: slot.secret, address }); // re-binds the session on success
// If the attempt was displaced while the SIWX round-trip was in progress — walletSignIn will still
// bind the session to `address`; clear such an outdated binding.
if (cancelled && getSessionAddress() === address) {
  clearAccessToken();
}
```

`getSessionAddress`/`clearAccessToken` are already imported in the module; behavior for the normal
(non-displaced) switching flow does not change.