### PR TITLE
xrpl-partial-payment-delivered

### DIFF
--- a/apps/wallet/src/lib/explorers/xrpl.ts
+++ b/apps/wallet/src/lib/explorers/xrpl.ts
@@ -75,14 +75,22 @@ export async function fetchXrplHistory(address: string, limit = 30): Promise<His
     const status: 'completed' | 'failed' =
       entry.meta?.TransactionResult === 'tesSUCCESS' ? 'completed' : 'failed';
 
+    // XRPL partial payments (tfPartialPayment) set `Amount` to the sender-specified *maximum*,
+    // while the value actually delivered is `meta.delivered_amount`. Displaying `Amount` lets an
+    // attacker show the victim a huge "incoming" payment that never arrived (fake-deposit social
+    // engineering), so always prefer the delivered amount when the ledger reports it.
+    const delivered = entry.meta?.delivered_amount;
+    const effectiveAmount =
+      delivered !== undefined && delivered !== 'unavailable' ? delivered : tx.Amount;
+
     let amount: HistoryTx['amount'];
-    if (typeof tx.Amount === 'string') {
-      amount = { currency: 'XRP' as const, drops: tx.Amount };
-    } else if (tx.Amount && typeof tx.Amount === 'object' && tx.Amount.value) {
+    if (typeof effectiveAmount === 'string') {
+      amount = { currency: 'XRP' as const, drops: effectiveAmount };
+    } else if (effectiveAmount && typeof effectiveAmount === 'object' && effectiveAmount.value) {
       amount = {
-        currency: tx.Amount.currency ?? '?',
-        value: tx.Amount.value,
-        issuer: tx.Amount.issuer ?? null,
+        currency: effectiveAmount.currency ?? '?',
+        value: effectiveAmount.value,
+        issuer: effectiveAmount.issuer ?? null,
       };
     } else {
       continue;


### PR DESCRIPTION
# XRPL history uses `tx.Amount` instead of `meta.delivered_amount` (partial payments)

- **Severity:** Medium-High (vulnerability: spoofing “incoming” payments, social engineering)
- **File:** `apps/wallet/src/lib/explorers/xrpl.ts`
- **Class:** incorrect amount source / XRPL partial-payment exploit

## Symptom / Impact

`fetchXrplHistory` constructs the transaction amount from `tx.Amount`. For payments with the
`tfPartialPayment` flag, the `Amount` field is the **maximum** specified by the sender, while the
actually delivered amount is in `meta.delivered_amount` and can be arbitrarily smaller.

The `delivered_amount` field was already declared in the response type (`AccountTxResponse`), but it is
not used anywhere.

## Failure Scenario

An attacker sends the victim a partial payment with `Amount = 5000 XRP`, but `delivered_amount = 0.000001 XRP`.
`fetchXrplHistory` is live (consumed in `features/history/hooks/useHistoryData.ts` → history list and
`TxDetailsDrawer`), so the wallet displays “incoming 5000 XRP” that never actually arrived — a classic fake
deposit scheme for deception.

This is display-only (does not affect outgoing transfers), but it directly enables financial loss via
misrepresentation. Canonical XRPL rule: always use `delivered_amount` for the delivered value.

## Fix

Prefer `meta.delivered_amount` when the ledger provides it (value `"unavailable"` for very old ledgers → fallback to `Amount`):

```ts
const delivered = entry.meta?.delivered_amount;
const effectiveAmount =
  delivered !== undefined && delivered !== 'unavailable' ? delivered : tx.Amount;

let amount: HistoryTx['amount'];
if (typeof effectiveAmount === 'string') {
  amount = { currency: 'XRP' as const, drops: effectiveAmount };
} else if (effectiveAmount && typeof effectiveAmount === 'object' && effectiveAmount.value) {
  amount = { currency: effectiveAmount.currency ?? '?', value: effectiveAmount.value, issuer: effectiveAmount.issuer ?? null };
} else {
  continue;
}
```

The `delivered_amount` type (`string | { value?, currency?, issuer? }`) matches the existing handling for `Amount`,
so the code path for issued-currency and XRP does not change—only the value source changes.